### PR TITLE
Add next tutorial hyperlink to oscs tutorial

### DIFF
--- a/patches/tutorials/05_oscs.axp
+++ b/patches/tutorials/05_oscs.axp
@@ -83,6 +83,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="14" y="658" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="06_envelopes.axp" x="154" y="658"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="note"/>


### PR DESCRIPTION
05_oscs.axp seems to be missing a hyperlink to the next tutorial in the series (06_envelopes.axp). This patch adds the link and a comment similar to what we have in the other tutorials.
