### PR TITLE
Add remaining tutorial hyperlinks

### DIFF
--- a/patches/tutorials/07_envelope_pitch.axp
+++ b/patches/tutorials/07_envelope_pitch.axp
@@ -104,9 +104,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>769</x>
-      <y>485</y>
-      <width>1748</width>
-      <height>1243</height>
+      <x>0</x>
+      <y>23</y>
+      <width>1052</width>
+      <height>828</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/07_envelope_pitch.axp
+++ b/patches/tutorials/07_envelope_pitch.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="14" y="14" text="one envelope for amplitude, another for pitch"/>
    <comment type="patch/comment" x="14" y="28" text="again: use the keyboard window to play!"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="70">

--- a/patches/tutorials/07_envelope_pitch.axp
+++ b/patches/tutorials/07_envelope_pitch.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="14" y="14" text="one envelope for amplitude, another for pitch"/>
    <comment type="patch/comment" x="14" y="28" text="again: use the keyboard window to play!"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="70">
@@ -58,6 +58,8 @@
       <attribs/>
    </obj>
    <comment type="patch/comment" x="182" y="518" text="mix output = bus_in + in1 * dial/64"/>
+   <comment type="patch/comment" x="28" y="658" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="08_lfo_pitch.axp" x="168" y="658"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="gate"/>
@@ -102,9 +104,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
-      <width>1052</width>
-      <height>828</height>
+      <x>769</x>
+      <y>485</y>
+      <width>1748</width>
+      <height>1243</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/08_lfo_pitch.axp
+++ b/patches/tutorials/08_lfo_pitch.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="14" y="14" text="One low frequency oscillator to modulate the pitch of an oscillator"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="42">
       <params/>

--- a/patches/tutorials/08_lfo_pitch.axp
+++ b/patches/tutorials/08_lfo_pitch.axp
@@ -87,9 +87,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1081</x>
-      <y>369</y>
-      <width>1340</width>
-      <height>902</height>
+      <x>0</x>
+      <y>23</y>
+      <width>1052</width>
+      <height>660</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/08_lfo_pitch.axp
+++ b/patches/tutorials/08_lfo_pitch.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="14" y="14" text="One low frequency oscillator to modulate the pitch of an oscillator"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="42">
       <params/>
@@ -47,6 +47,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="28" y="518" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="09_lfo_amplitude.axp" x="168" y="518"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="note"/>
@@ -85,9 +87,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
-      <width>1052</width>
-      <height>660</height>
+      <x>1081</x>
+      <y>369</y>
+      <width>1340</width>
+      <height>902</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/09_lfo_amplitude.axp
+++ b/patches/tutorials/09_lfo_amplitude.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="28" y="14" text="One low frequency oscillator to modulate the amplitude of an oscillator"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="28" y="56">
       <params/>

--- a/patches/tutorials/09_lfo_amplitude.axp
+++ b/patches/tutorials/09_lfo_amplitude.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="28" y="14" text="One low frequency oscillator to modulate the amplitude of an oscillator"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="28" y="56">
       <params/>
@@ -63,6 +63,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="14" y="644" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="10_amplitude_modulation.axp" x="14" y="672"/>
    <nets>
       <net>
          <source obj="saw_1" outlet="wave"/>
@@ -113,9 +115,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
-      <width>940</width>
-      <height>786</height>
+      <x>1487</x>
+      <y>561</y>
+      <width>962</width>
+      <height>980</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/09_lfo_amplitude.axp
+++ b/patches/tutorials/09_lfo_amplitude.axp
@@ -115,9 +115,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1487</x>
-      <y>561</y>
-      <width>962</width>
-      <height>980</height>
+      <x>0</x>
+      <y>23</y>
+      <width>940</width>
+      <height>786</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/10_amplitude_modulation.axp
+++ b/patches/tutorials/10_amplitude_modulation.axp
@@ -90,9 +90,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>491</x>
-      <y>375</y>
-      <width>1008</width>
-      <height>1086</height>
+      <x>0</x>
+      <y>23</y>
+      <width>898</width>
+      <height>772</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/10_amplitude_modulation.axp
+++ b/patches/tutorials/10_amplitude_modulation.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="14" y="14" text="amplitude modulation, sine wave carrier, sine wave modulator, 100% modulation depth"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="42">
       <params/>
@@ -45,6 +45,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="28" y="616" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="11_subtractive_simple.axp" x="28" y="644"/>
    <nets>
       <net>
          <source obj="osc_2" outlet="wave"/>
@@ -88,9 +90,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
-      <width>898</width>
-      <height>772</height>
+      <x>491</x>
+      <y>375</y>
+      <width>1008</width>
+      <height>1086</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/10_amplitude_modulation.axp
+++ b/patches/tutorials/10_amplitude_modulation.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="14" y="14" text="amplitude modulation, sine wave carrier, sine wave modulator, 100% modulation depth"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="42">
       <params/>

--- a/patches/tutorials/11_subtractive_simple.axp
+++ b/patches/tutorials/11_subtractive_simple.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>
@@ -110,6 +110,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="42" y="826" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="12_subtractive_lfo_env.axp" x="42" y="854"/>
    <nets>
       <net>
          <source obj="saw_1" outlet="wave"/>
@@ -189,9 +191,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>391</x>
-      <y>100</y>
-      <width>1276</width>
-      <height>1038</height>
+      <x>393</x>
+      <y>156</y>
+      <width>1305</width>
+      <height>1101</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/11_subtractive_simple.axp
+++ b/patches/tutorials/11_subtractive_simple.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>

--- a/patches/tutorials/11_subtractive_simple.axp
+++ b/patches/tutorials/11_subtractive_simple.axp
@@ -191,9 +191,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>393</x>
-      <y>156</y>
-      <width>1305</width>
-      <height>1101</height>
+      <x>391</x>
+      <y>100</y>
+      <width>1276</width>
+      <height>1038</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/12_subtractive_lfo_env.axp
+++ b/patches/tutorials/12_subtractive_lfo_env.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>
@@ -75,6 +75,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="28" y="700" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="13_additive_harmonic.axp" x="28" y="728"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="gate"/>
@@ -133,9 +135,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>213</x>
-      <y>55</y>
-      <width>828</width>
-      <height>912</height>
+      <x>1002</x>
+      <y>168</y>
+      <width>1527</width>
+      <height>1124</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/12_subtractive_lfo_env.axp
+++ b/patches/tutorials/12_subtractive_lfo_env.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>

--- a/patches/tutorials/12_subtractive_lfo_env.axp
+++ b/patches/tutorials/12_subtractive_lfo_env.axp
@@ -135,9 +135,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1002</x>
-      <y>168</y>
-      <width>1527</width>
-      <height>1124</height>
+      <x>213</x>
+      <y>55</y>
+      <width>828</width>
+      <height>912</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/13_additive_harmonic.axp
+++ b/patches/tutorials/13_additive_harmonic.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>

--- a/patches/tutorials/13_additive_harmonic.axp
+++ b/patches/tutorials/13_additive_harmonic.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>
@@ -86,6 +86,8 @@
    <comment type="patch/comment" x="616" y="490" text="mix the three sources"/>
    <comment type="patch/comment" x="420" y="504" text="multiply envelope with oscillation"/>
    <comment type="patch/comment" x="504" y="518" text="watch the envelopes here"/>
+   <comment type="patch/comment" x="14" y="560" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="14_additive_inharmonic.axp" x="14" y="588"/>
    <nets>
       <net>
          <source obj="mix_1" outlet="out"/>
@@ -149,9 +151,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
-      <width>1094</width>
-      <height>828</height>
+      <x>863</x>
+      <y>479</y>
+      <width>1816</width>
+      <height>805</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/13_additive_harmonic.axp
+++ b/patches/tutorials/13_additive_harmonic.axp
@@ -151,9 +151,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>863</x>
-      <y>479</y>
-      <width>1816</width>
-      <height>805</height>
+      <x>0</x>
+      <y>23</y>
+      <width>1094</width>
+      <height>828</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/14_additive_inharmonic.axp
+++ b/patches/tutorials/14_additive_inharmonic.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>

--- a/patches/tutorials/14_additive_inharmonic.axp
+++ b/patches/tutorials/14_additive_inharmonic.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>
@@ -86,6 +86,8 @@
    <comment type="patch/comment" x="616" y="490" text="mix the three sources"/>
    <comment type="patch/comment" x="420" y="504" text="multiply envelope with oscillation"/>
    <comment type="patch/comment" x="490" y="518" text="watch the envelopes here"/>
+   <comment type="patch/comment" x="14" y="546" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="15_waveshaper.axp" x="14" y="574"/>
    <nets>
       <net>
          <source obj="mix_1" outlet="out"/>
@@ -149,9 +151,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
-      <width>1080</width>
-      <height>828</height>
+      <x>835</x>
+      <y>197</y>
+      <width>2071</width>
+      <height>854</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/14_additive_inharmonic.axp
+++ b/patches/tutorials/14_additive_inharmonic.axp
@@ -151,9 +151,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>835</x>
-      <y>197</y>
-      <width>2071</width>
-      <height>854</height>
+      <x>0</x>
+      <y>23</y>
+      <width>1080</width>
+      <height>828</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/15_waveshaper.axp
+++ b/patches/tutorials/15_waveshaper.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="42" y="14" text="waveshaper: time domain tranfert function"/>
    <comment type="patch/comment" x="84" y="28" text="adds harmonics to the spectrum"/>
    <comment type="patch/comment" x="126" y="42" text="(but also aliases!)"/>
@@ -135,6 +135,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="14" y="616" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="16_frequency_modulation.axp" x="14" y="644"/>
    <nets>
       <net>
          <source obj="cbp1" outlet="out"/>
@@ -186,8 +188,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
+      <x>1242</x>
+      <y>299</y>
       <width>1080</width>
       <height>884</height>
    </windowPos>

--- a/patches/tutorials/15_waveshaper.axp
+++ b/patches/tutorials/15_waveshaper.axp
@@ -188,8 +188,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1242</x>
-      <y>299</y>
+      <x>0</x>
+      <y>23</y>
       <width>1080</width>
       <height>884</height>
    </windowPos>

--- a/patches/tutorials/15_waveshaper.axp
+++ b/patches/tutorials/15_waveshaper.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="42" y="14" text="waveshaper: time domain tranfert function"/>
    <comment type="patch/comment" x="84" y="28" text="adds harmonics to the spectrum"/>
    <comment type="patch/comment" x="126" y="42" text="(but also aliases!)"/>

--- a/patches/tutorials/16_frequency_modulation.axp
+++ b/patches/tutorials/16_frequency_modulation.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="14" y="14" text="frequency modulation, sine wave carrier, sine wave modulator"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="42">
       <params/>

--- a/patches/tutorials/16_frequency_modulation.axp
+++ b/patches/tutorials/16_frequency_modulation.axp
@@ -86,8 +86,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1562</x>
-      <y>826</y>
+      <x>256</x>
+      <y>156</y>
       <width>1010</width>
       <height>604</height>
    </windowPos>

--- a/patches/tutorials/16_frequency_modulation.axp
+++ b/patches/tutorials/16_frequency_modulation.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="14" y="14" text="frequency modulation, sine wave carrier, sine wave modulator"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="42">
       <params/>
@@ -45,6 +45,8 @@
    </obj>
    <comment type="patch/comment" x="126" y="308" text="What is called &quot;FM&quot; in ads and magazines is really PM : Phase Modulation"/>
    <comment type="patch/comment" x="126" y="322" text="Phase modulation preserves the fundamental frequency, while FM does not, making it more well behaving"/>
+   <comment type="patch/comment" x="28" y="420" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="17_frequency_modulation_envelope.axp" x="154" y="420"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="note"/>
@@ -84,8 +86,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>256</x>
-      <y>156</y>
+      <x>1562</x>
+      <y>826</y>
       <width>1010</width>
       <height>604</height>
    </windowPos>

--- a/patches/tutorials/17_frequency_modulation_envelope.axp
+++ b/patches/tutorials/17_frequency_modulation_envelope.axp
@@ -104,9 +104,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>223</x>
-      <y>960</y>
-      <width>1263</width>
-      <height>668</height>
+      <x>720</x>
+      <y>217</y>
+      <width>926</width>
+      <height>618</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/17_frequency_modulation_envelope.axp
+++ b/patches/tutorials/17_frequency_modulation_envelope.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="14" y="14" text="frequency modulation, sine wave carrier, sine wave modulator"/>
    <comment type="patch/comment" x="182" y="42" text="evelope to control modulation depth"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="56">
@@ -54,6 +54,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="14" y="420" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="18_combfilter.axp" x="140" y="420"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="note"/>
@@ -102,9 +104,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>720</x>
-      <y>217</y>
-      <width>926</width>
-      <height>618</height>
+      <x>223</x>
+      <y>960</y>
+      <width>1263</width>
+      <height>668</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/17_frequency_modulation_envelope.axp
+++ b/patches/tutorials/17_frequency_modulation_envelope.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="14" y="14" text="frequency modulation, sine wave carrier, sine wave modulator"/>
    <comment type="patch/comment" x="182" y="42" text="evelope to control modulation depth"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="56">

--- a/patches/tutorials/18_combfilter.axp
+++ b/patches/tutorials/18_combfilter.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>

--- a/patches/tutorials/18_combfilter.axp
+++ b/patches/tutorials/18_combfilter.axp
@@ -97,8 +97,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1021</x>
-      <y>484</y>
+      <x>71</x>
+      <y>28</y>
       <width>1234</width>
       <height>548</height>
    </windowPos>

--- a/patches/tutorials/18_combfilter.axp
+++ b/patches/tutorials/18_combfilter.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="14">
       <params/>
       <attribs/>
@@ -54,6 +54,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="14" y="350" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="19_excitation_resonator.axp" x="140" y="350"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="note"/>
@@ -95,8 +97,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>71</x>
-      <y>28</y>
+      <x>1021</x>
+      <y>484</y>
       <width>1234</width>
       <height>548</height>
    </windowPos>

--- a/patches/tutorials/19_excitation_resonator.axp
+++ b/patches/tutorials/19_excitation_resonator.axp
@@ -142,8 +142,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1463</x>
-      <y>685</y>
+      <x>114</x>
+      <y>26</y>
       <width>1276</width>
       <height>800</height>
    </windowPos>

--- a/patches/tutorials/19_excitation_resonator.axp
+++ b/patches/tutorials/19_excitation_resonator.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="0" y="14">
       <params/>
       <attribs/>

--- a/patches/tutorials/19_excitation_resonator.axp
+++ b/patches/tutorials/19_excitation_resonator.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="0" y="14">
       <params/>
       <attribs/>
@@ -80,6 +80,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="28" y="532" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="20_karplus_strong.axp" x="154" y="532"/>
    <nets>
       <net>
          <source obj="envd1" outlet="env"/>
@@ -140,8 +142,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>114</x>
-      <y>26</y>
+      <x>1463</x>
+      <y>685</y>
       <width>1276</width>
       <height>800</height>
    </windowPos>

--- a/patches/tutorials/20_karplus_strong.axp
+++ b/patches/tutorials/20_karplus_strong.axp
@@ -125,8 +125,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1739</x>
-      <y>348</y>
+      <x>0</x>
+      <y>23</y>
       <width>1024</width>
       <height>660</height>
    </windowPos>

--- a/patches/tutorials/20_karplus_strong.axp
+++ b/patches/tutorials/20_karplus_strong.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="14" y="14" text="play with the piano!"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="42">
       <params/>

--- a/patches/tutorials/20_karplus_strong.axp
+++ b/patches/tutorials/20_karplus_strong.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="14" y="14" text="play with the piano!"/>
    <obj type="midi/in/keyb" sha="b8deb97637e54be31fcb62e849e4fa406e72256e" name="keyb1" x="14" y="42">
       <params/>
@@ -70,6 +70,8 @@
       <attribs/>
    </obj>
    <comment type="patch/comment" x="56" y="350" text="bug: tuning reference is incorrect"/>
+   <comment type="patch/comment" x="14" y="462" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="21_modulated_delay1.axp" x="140" y="462"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="gate"/>
@@ -123,8 +125,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
+      <x>1739</x>
+      <y>348</y>
       <width>1024</width>
       <height>660</height>
    </windowPos>

--- a/patches/tutorials/21_modulated_delay1.axp
+++ b/patches/tutorials/21_modulated_delay1.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="28" y="14" text="demonstration: modulated delay lines for effect processing"/>
    <comment type="patch/comment" x="70" y="42" text="test signal selection"/>
    <obj type="ctrl/i radio 4 v" sha="d755521996a6bf57298aeed6198f271783137da1" name="i_2" x="28" y="56">

--- a/patches/tutorials/21_modulated_delay1.axp
+++ b/patches/tutorials/21_modulated_delay1.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="28" y="14" text="demonstration: modulated delay lines for effect processing"/>
    <comment type="patch/comment" x="70" y="42" text="test signal selection"/>
    <obj type="ctrl/i radio 4 v" sha="d755521996a6bf57298aeed6198f271783137da1" name="i_2" x="28" y="56">
@@ -106,6 +106,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="28" y="602" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="22_overlap_add_shifter.axp" x="154" y="602"/>
    <nets>
       <net>
          <source obj="osc_1" outlet="wave"/>
@@ -175,8 +177,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>304</x>
-      <y>108</y>
+      <x>1778</x>
+      <y>702</y>
       <width>1066</width>
       <height>772</height>
    </windowPos>

--- a/patches/tutorials/21_modulated_delay1.axp
+++ b/patches/tutorials/21_modulated_delay1.axp
@@ -177,8 +177,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1778</x>
-      <y>702</y>
+      <x>304</x>
+      <y>108</y>
       <width>1066</width>
       <height>772</height>
    </windowPos>

--- a/patches/tutorials/22_overlap_add_shifter.axp
+++ b/patches/tutorials/22_overlap_add_shifter.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="28" y="14" text="demonstration: modulated delay lines, overlap-add"/>
    <obj type="ctrl/i radio 4 v" sha="d755521996a6bf57298aeed6198f271783137da1" name="i_2" x="42" y="112">
       <params>

--- a/patches/tutorials/22_overlap_add_shifter.axp
+++ b/patches/tutorials/22_overlap_add_shifter.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="28" y="14" text="demonstration: modulated delay lines, overlap-add"/>
    <obj type="ctrl/i radio 4 v" sha="d755521996a6bf57298aeed6198f271783137da1" name="i_2" x="42" y="112">
       <params>
@@ -97,6 +97,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="42" y="826" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="23_stretcher.axp" x="168" y="826"/>
    <nets>
       <net>
          <source obj="cbp1" outlet="out"/>
@@ -168,9 +170,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>616</x>
-      <y>126</y>
-      <width>986</width>
-      <height>977</height>
+      <x>1579</x>
+      <y>234</y>
+      <width>1174</width>
+      <height>947</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/22_overlap_add_shifter.axp
+++ b/patches/tutorials/22_overlap_add_shifter.axp
@@ -170,9 +170,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1579</x>
-      <y>234</y>
-      <width>1174</width>
-      <height>947</height>
+      <x>616</x>
+      <y>126</y>
+      <width>986</width>
+      <height>977</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/23_stretcher.axp
+++ b/patches/tutorials/23_stretcher.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <obj type="ctrl/dial p" sha="1f21216639bb798a4ea7902940999a5bcfd0de90" name="c1" x="80" y="20">
       <params>
          <frac32.u.map name="value" value="0.0"/>
@@ -94,6 +94,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="56" y="630" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="24_wavetable.axp" x="182" y="630"/>
    <nets>
       <net>
          <source obj="phasor3q_1" outlet="phasor0"/>
@@ -174,8 +176,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>346</x>
-      <y>169</y>
+      <x>1429</x>
+      <y>152</y>
       <width>1150</width>
       <height>830</height>
    </windowPos>

--- a/patches/tutorials/23_stretcher.axp
+++ b/patches/tutorials/23_stretcher.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <obj type="ctrl/dial p" sha="1f21216639bb798a4ea7902940999a5bcfd0de90" name="c1" x="80" y="20">
       <params>
          <frac32.u.map name="value" value="0.0"/>

--- a/patches/tutorials/23_stretcher.axp
+++ b/patches/tutorials/23_stretcher.axp
@@ -176,8 +176,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1429</x>
-      <y>152</y>
+      <x>346</x>
+      <y>169</y>
       <width>1150</width>
       <height>830</height>
    </windowPos>

--- a/patches/tutorials/24_wavetable.axp
+++ b/patches/tutorials/24_wavetable.axp
@@ -133,8 +133,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1851</x>
-      <y>419</y>
+      <x>0</x>
+      <y>23</y>
       <width>982</width>
       <height>646</height>
    </windowPos>

--- a/patches/tutorials/24_wavetable.axp
+++ b/patches/tutorials/24_wavetable.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="14" y="14" text="time domain table of one period of oscillation"/>
    <comment type="patch/comment" x="266" y="14" text="slow modulation of pitch: demonstrates audible interpolation artefacts (aliases)"/>
    <obj type="table/allocate 32b 16sliders" sha="2227408087d0108a79d19893c9bcca8343f9f004" name="tab" x="14" y="28">
@@ -85,6 +85,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="14" y="448" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="25_execution_order.axp" x="140" y="448"/>
    <nets>
       <net>
          <source obj="phasor3_1" outlet="phasor"/>
@@ -131,8 +133,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
+      <x>1851</x>
+      <y>419</y>
       <width>982</width>
       <height>646</height>
    </windowPos>

--- a/patches/tutorials/24_wavetable.axp
+++ b/patches/tutorials/24_wavetable.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="14" y="14" text="time domain table of one period of oscillation"/>
    <comment type="patch/comment" x="266" y="14" text="slow modulation of pitch: demonstrates audible interpolation artefacts (aliases)"/>
    <obj type="table/allocate 32b 16sliders" sha="2227408087d0108a79d19893c9bcca8343f9f004" name="tab" x="14" y="28">

--- a/patches/tutorials/25_execution_order.axp
+++ b/patches/tutorials/25_execution_order.axp
@@ -76,9 +76,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>916</x>
-      <y>887</y>
-      <width>1598</width>
-      <height>784</height>
+      <x>0</x>
+      <y>23</y>
+      <width>1030</width>
+      <height>750</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/25_execution_order.axp
+++ b/patches/tutorials/25_execution_order.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="126" y="28" text="execution order = reading order : left to right, top to bottom"/>
    <obj type="ctrl/dial p" sha="1f21216639bb798a4ea7902940999a5bcfd0de90" name="one" x="120" y="60">
       <params>
@@ -39,6 +39,8 @@
       <attribs/>
    </obj>
    <comment type="patch/comment" x="280" y="448" text="upward link (from object seven to object six)  introduces a latch!"/>
+   <comment type="patch/comment" x="28" y="532" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="26_sawtooth_straight_vs_bandlimited.axp" x="154" y="532"/>
    <nets>
       <net>
          <source obj="one" outlet="out"/>
@@ -74,9 +76,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
-      <width>1030</width>
-      <height>750</height>
+      <x>916</x>
+      <y>887</y>
+      <width>1598</width>
+      <height>784</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/25_execution_order.axp
+++ b/patches/tutorials/25_execution_order.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="126" y="28" text="execution order = reading order : left to right, top to bottom"/>
    <obj type="ctrl/dial p" sha="1f21216639bb798a4ea7902940999a5bcfd0de90" name="one" x="120" y="60">
       <params>

--- a/patches/tutorials/26_sawtooth_straight_vs_bandlimited.axp
+++ b/patches/tutorials/26_sawtooth_straight_vs_bandlimited.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <obj type="midi/in/keyb" sha="d2b06e818348b14523c68fd021077192860093c0" name="keyb1" x="40" y="40">
       <params/>
       <attribs/>

--- a/patches/tutorials/26_sawtooth_straight_vs_bandlimited.axp
+++ b/patches/tutorials/26_sawtooth_straight_vs_bandlimited.axp
@@ -96,9 +96,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>1285</x>
-      <y>294</y>
-      <width>1574</width>
-      <height>912</height>
+      <x>0</x>
+      <y>23</y>
+      <width>1070</width>
+      <height>650</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/26_sawtooth_straight_vs_bandlimited.axp
+++ b/patches/tutorials/26_sawtooth_straight_vs_bandlimited.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <obj type="midi/in/keyb" sha="d2b06e818348b14523c68fd021077192860093c0" name="keyb1" x="40" y="40">
       <params/>
       <attribs/>
@@ -52,6 +52,8 @@
       <params/>
       <attribs/>
    </obj>
+   <comment type="patch/comment" x="42" y="616" text="Open next tutorial -&gt;"/>
+   <hyperlink type="patch/hyperlink" name="27_simple_sequencer.axp" x="168" y="616"/>
    <nets>
       <net>
          <source obj="keyb1" outlet="note"/>
@@ -94,9 +96,9 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>0</x>
-      <y>23</y>
-      <width>1070</width>
-      <height>650</height>
+      <x>1285</x>
+      <y>294</y>
+      <width>1574</width>
+      <height>912</height>
    </windowPos>
 </patch-1.0>

--- a/patches/tutorials/27_simple_sequencer.axp
+++ b/patches/tutorials/27_simple_sequencer.axp
@@ -242,8 +242,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>754</x>
-      <y>947</y>
+      <x>323</x>
+      <y>359</y>
       <width>1615</width>
       <height>839</height>
    </windowPos>

--- a/patches/tutorials/27_simple_sequencer.axp
+++ b/patches/tutorials/27_simple_sequencer.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.8">
+<patch-1.0 appVersion="1.0.10">
    <comment type="patch/comment" x="28" y="14" text="fire event on start"/>
    <obj type="const/i" sha="15b9dce9232a04e8881936a6ea800e66ae8e0da9" uuid="e202f44b2df17ae0b3e663b98ea6b14c8ff00408" name="counter_1" x="28" y="28">
       <params/>
@@ -242,8 +242,8 @@
    </settings>
    <notes><![CDATA[]]></notes>
    <windowPos>
-      <x>323</x>
-      <y>359</y>
+      <x>754</x>
+      <y>947</y>
       <width>1615</width>
       <height>839</height>
    </windowPos>

--- a/patches/tutorials/27_simple_sequencer.axp
+++ b/patches/tutorials/27_simple_sequencer.axp
@@ -1,4 +1,4 @@
-<patch-1.0 appVersion="1.0.10">
+<patch-1.0 appVersion="1.0.8">
    <comment type="patch/comment" x="28" y="14" text="fire event on start"/>
    <obj type="const/i" sha="15b9dce9232a04e8881936a6ea800e66ae8e0da9" uuid="e202f44b2df17ae0b3e663b98ea6b14c8ff00408" name="counter_1" x="28" y="28">
       <params/>


### PR DESCRIPTION
It turns out that "next tutorial" hyperlinks were missing from the majority of the tutorials. This patch adds them and fixes the tutorial numbering slightly (26 was repeated).
