### PR TITLE
1.0.12

### DIFF
--- a/objects/filter/allpass.axo
+++ b/objects/filter/allpass.axo
@@ -27,7 +27,6 @@ for (i=0;i<attr_delay;i++)
 dpos = 0;
 ]]></code.init>
       <code.krate><![CDATA[int32_t g2 = param_g<<4;
-int32_t g2c = ((1<<31)-1)-g2;
 ]]></code.krate>
       <code.srate><![CDATA[int32_t dout =  d[dpos]<<16;
 int32_t din = ___SMMLA(g2,dout,inlet_in>>1);

--- a/objects/midi/ctrl/mpe.axo
+++ b/objects/midi/ctrl/mpe.axo
@@ -57,7 +57,6 @@ outlet_pitch = _pitch;
 ]]></code.krate>
       <code.midihandler><![CDATA[
 if ((status == MIDI_NOTE_ON + attr_midichannel) && (data2)) {
-  _bend = 0;
   _velo = data2<<20;
   _note = data1-64;
   _gate = 1<<27;

--- a/objects/midi/ctrl/mpe.axo
+++ b/objects/midi/ctrl/mpe.axo
@@ -57,6 +57,7 @@ outlet_pitch = _pitch;
 ]]></code.krate>
       <code.midihandler><![CDATA[
 if ((status == MIDI_NOTE_ON + attr_midichannel) && (data2)) {
+  _bend = 0;
   _velo = data2<<20;
   _note = data1-64;
   _gate = 1<<27;

--- a/objects/midi/in/cc hr i.axo
+++ b/objects/midi/in/cc hr i.axo
@@ -20,7 +20,7 @@
 uint32_t _ccv;
 uint8_t ntrig;
 ]]></code.declaration>
-      <code.init><![CDATA[_ccv = attr_default;ccl=0;ntrig=0;
+      <code.init><![CDATA[_ccv = attr_default << 20;ccl=0;ntrig=0;
 ]]></code.init>
       <code.krate><![CDATA[ outlet_midiCC= _ccv;
 outlet_trig = ntrig;

--- a/objects/midi/in/cc hr ii.axo
+++ b/objects/midi/in/cc hr ii.axo
@@ -21,7 +21,7 @@
 uint32_t _ccv;
 uint8_t ntrig;
 ]]></code.declaration>
-      <code.init><![CDATA[_ccv = attr_default;ccl=0;ntrig=0;
+      <code.init><![CDATA[_ccv = attr_default << 20;ccl=0;ntrig=0;
 ]]></code.init>
       <code.krate><![CDATA[ outlet_midiCC= _ccv;
 outlet_trig = ntrig;


### PR DESCRIPTION
Three tiny fixes.

RE Linnstrument and MPE: The linnstrument doesn't update its current pitchbend value to 0 when a new note is triggered. This resulted in a glitch, where the bend output of the MPE object would still contain the pitchbend value from the last note - meaning the new note was played at the wrong pitch until a new pitchbend message is received.