### PR TITLE
Fix MIDI clock output objects

### DIFF
--- a/objects/midi/intern/clock.axo
+++ b/objects/midi/intern/clock.axo
@@ -36,8 +36,12 @@ rstp = 0;]]></code.init>
 }
 if (inlet_run && !_active) {
   _active = 1;
-  if (_pos24ppq)     PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_CONTINUE,0,0);
-  else     PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_START,0,0);
+  if (_pos24ppq) {
+    PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_CONTINUE,0,0);
+  } else {
+    PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_START,0,0);
+    PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_TIMING_CLOCK,0,0);
+  }
 } else if (!inlet_run && _active){
   _active = 0;
   PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_STOP,0,0);

--- a/objects/midi/intern/clock.axo
+++ b/objects/midi/intern/clock.axo
@@ -36,8 +36,8 @@ rstp = 0;]]></code.init>
 }
 if (inlet_run && !_active) {
   _active = 1;
-  if (_pos24ppq)     PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_START,0,0);
-  else     PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_CONTINUE,0,0);
+  if (_pos24ppq)     PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_CONTINUE,0,0);
+  else     PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_START,0,0);
 } else if (!inlet_run && _active){
   _active = 0;
   PatchMidiInHandler(MIDI_DEVICE_INTERNAL, 0,MIDI_STOP,0,0);

--- a/objects/midi/out/clock.axo
+++ b/objects/midi/out/clock.axo
@@ -60,8 +60,12 @@ rstp = 0;]]></code.init>
 }
 if (inlet_run && !_active) {
   _active = 1;
-  if (_pos24ppq)     MidiSend1((midi_device_t) attr_device, MIDI_CONTINUE);
-  else     MidiSend1((midi_device_t) attr_device, MIDI_START);
+  if (_pos24ppq) {
+    MidiSend1((midi_device_t) attr_device, MIDI_CONTINUE);
+  } else {
+    MidiSend1((midi_device_t) attr_device, MIDI_START);
+    MidiSend1((midi_device_t) attr_device, MIDI_TIMING_CLOCK);
+  }
 } else if (!inlet_run && _active){
   _active = 0;
   MidiSend1((midi_device_t) attr_device, MIDI_STOP);


### PR DESCRIPTION
These changes fix the following issues:


### `midi/out/clock`

* In order for most (if not all) external MIDI devices to properly synchronize as clock slave at 24ppqn, a clock pulse must be sent immediately after `MIDI_START`. This is consistent across all the devices I tested with and is mentioned in [this document](http://midi.teragonaudio.com/tech/midispec/seq.htm) quoted below. Without this behavior, MIDI slave devices will run 1/24 of a quarter note behind Axoloti's internal sequences, which is plainly audible.

> The master needs to be able to start the slave precisely when the master starts. The master does this by sending a MIDI Start message. The MIDI Start message alerts the slave that, upon receipt of the very next MIDI Clock message, the slave should start the playback of its sequence. In other words, the MIDI Start puts the slave in "play mode", and the receipt of that first MIDI Clock marks the initial downbeat of the song (i.e., MIDI Beat 0). What this means is that (typically) the master sends out that MIDI Clock "downbeat" immediately after the MIDI Start. (In practice, most masters allow a 1 millisecond interval in between the MIDI Start and subsequent MIDI Clock messages in order to give the slave an opportunity to prepare itself for playback). **In essence, a MIDI Start is just a warning to let the slave know that the next MIDI Clock represents the downbeat, and playback is to start then.**


### `midi/intern/clock`

* The `MIDI_START` and `MIDI_CONTINUE` messages were swapped. `MIDI_CONTINUE` should be used if the internal clock position is greater than zero.
* For consistency with `midi/out/clock`, the internal clock device should also send a MIDI clock pulse immediately after the start message.