### PR TITLE
Fix compilation error for string outlets

### DIFF
--- a/objects/patch/outlet string.axo
+++ b/objects/patch/outlet string.axo
@@ -13,7 +13,7 @@
       <attribs/>
       <code.declaration><![CDATA[char * _outlet;
 ]]></code.declaration>
-      <code.krate><![CDATA[   _outlet = inlet_outlet;
+      <code.krate><![CDATA[   _outlet = (char *)inlet_outlet;
 ]]></code.krate>
    </obj.normal>
 </objdefs>


### PR DESCRIPTION
While trying to build a subpatch with a string outlet, I stumbled upon this error:
`~/Documents/axoloti/build/xpatch.cpp: In member function 'void rootc::instanceoutlet__1::dsp(const char*)':
~/Documents/axoloti/build/xpatch.cpp:65:12: error: invalid conversion from 'const char*' to 'char*' [-fpermissive]
    _outlet = inlet_outlet;
            ^
make: *** [~/Documents/axoloti/build/xpatch.bin] Error 1
shell task failed, exit value: 2`
It seems to be related to this old commit on axoloti repo (https://github.com/axoloti/axoloti/commit/5c06f2b13c0802226855beac4bec14bac7b6ce8c) where the same fix was applied.